### PR TITLE
Fix: Changed 'bytes to higher order conversion' function implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ If the module hasn't been installed / not present in `package.json`, it assumes 
 
 - [wix/import-cost](https://github.com/wix/import-cost/tree/master/packages/import-cost) -
   Enables traversing `node_modules` to find the module cost.
-- [pastelskys](https://github.com/pastelsky/bundlephobia])
-[bundlephobia](https://bundlephobia.com/]) - Providing the means to find module
+- [pastelskys](https://github.com/pastelsky/bundlephobia)
+[bundlephobia](https://bundlephobia.com/) - Providing the means to find module
 cost via an API. [Used as a fallback mechanism]
 
-Do check them amount ^\_^
+Do check them out! ^_^
 
 ### Contributing
 

--- a/lib/importcost.js
+++ b/lib/importcost.js
@@ -1,6 +1,5 @@
 'use babel';
 
-import { CompositeDisposable } from 'atom';
 import labelize from './labelize';
 import codewalk from './walk';
 
@@ -18,7 +17,7 @@ export default {
     })
   },
 
-  tail () {
+  tail() {
     this.clear();
     const editor = atom.workspace.getActiveTextEditor();
     if(!editor) return ;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,10 +1,11 @@
 'use babel';
 
-const convertBytes = bytes => {
-  if(!bytes) return 0;
-  else if(bytes < 5000000) return ((bytes / 1000).toFixed(1) + "KB");
-  else if (bytes < 50000000) return ((bytes / 1000000).toFixed(2) + "MB");
-  else return ((bytes / 1000000000).toFixed(2) + "GB");
+const convertBytes = (bytes, mantissa = 2) => {
+  if (bytes == 0) return 0;
+  const NUMBER_OF_PEAS_IN_A_POD = 1024;
+  const METRIC_LIST = ["Bytes", "KB", "MB", "GB", "TB", "PB", "EB", "ZB", "YB"];
+  const powerToBeRaisedTo = Math.floor(Math.log(bytes) / Math.log(NUMBER_OF_PEAS_IN_A_POD));
+  return parseFloat((bytes / Math.pow(NUMBER_OF_PEAS_IN_A_POD, powerToBeRaisedTo)).toFixed(mantissa)) + " " + METRIC_LIST[powerToBeRaisedTo];
 }
 
 module.exports = {


### PR DESCRIPTION
- Fixes a typo in the README.md file
- Fixes the byte to higher order metric conversion function to take into account the fact that 1KB = 1024 bytes and so on.

Attaching a screenshot below that shows the difference in computed size- 

<img width="1186" alt="screen shot 2019-01-09 at 12 39 00 am" src="https://user-images.githubusercontent.com/25174717/50852957-02442f80-13a7-11e9-91c6-8c4682bfdcef.png">

Also gives the flexibility to configure how accurate you want the results to be: 
<img width="1151" alt="screen shot 2019-01-09 at 12 53 51 am" src="https://user-images.githubusercontent.com/25174717/50853761-2f91dd00-13a9-11e9-943c-ef9066abfba5.png">


First of all, let me express my deep admiration and respect that I have for you as a person and for your work. You are actually a myth at the place I work. People literally worship you there. Thanks for all the inspiration! :D